### PR TITLE
fix: add oci URL scheme when resolving chart

### DIFF
--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -730,6 +730,13 @@ func (o *Options) ResolveChartRepositoryURL() (string, error) {
 			return chartRepo, nil
 		}
 
+		if o.DevEnvContext.Requirements.Cluster.ChartKind == jxcore.ChartRepositoryTypeOCI {
+			// Append oci scheme to the URL if not already present
+			if !strings.HasPrefix(chartRepo, "oci://") {
+				chartRepo = "oci://" + chartRepo
+			}
+		}
+
 		// A repo URL that is local to this cluster would not work when deploying to a remote cluster.
 		if !IsLocalChartRepository(chartRepo) {
 			return chartRepo, nil


### PR DESCRIPTION
### Changes
* Add check to ensure `oci://` URL scheme is appended to`chartRepo` when resolving the chart repository URL

### Context

If a URL scheme is not specified, `ResolveChartRepositoryURL` will always assume the repository is internal, bypassing the remaining logic.

This ensures compatibility with `jx-requirements.yaml`, which expects a hostname and path only ([as-per example from `jx-gitops release`](https://github.com/jenkins-x-plugins/jx-gitops/blob/ba404fa408d230b49afda3b68d56b1044c04e56a/pkg/cmd/helm/release/release.go#L353))
