### PR TITLE
chore: clear disk space during release step

### DIFF
--- a/.github/workflows/jenkins-x/upload-binaries.sh
+++ b/.github/workflows/jenkins-x/upload-binaries.sh
@@ -17,4 +17,4 @@ export REV=$(git rev-parse HEAD)
 export GOVERSION="1.22.3"
 export ROOTPACKAGE="github.com/$REPOSITORY"
 
-goreleaser release
+goreleaser release --clean --parallelism=1 --timeout=30m


### PR DESCRIPTION
### Changes
* Check disk usage, and space-clearing flags to `gorelease release` step of `upload-binaries.sh` script

### Context

The release step is failing as the runner is low on disk space:

```
    error=
    │ build failed: exit status 1: # command-line-arguments
    │ /usr/local/go/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device
    target=linux_arm64_v8.0
```

Adding the `--clear` flag should ensure the runner has enough disk to complete the release process, while setting `--parallelism=1` should prevent spikes in disk consumption