### PR TITLE
feat: support sparse + shallow clones

### DIFF
--- a/pkg/envctx/env_context.go
+++ b/pkg/envctx/env_context.go
@@ -34,6 +34,10 @@ type EnvironmentContext struct {
 
 	// GitRepository the current name  of the current git repository we are in
 	GitRepository string
+
+	// SparseCheckout when true the dev environment clone used to load the version stream uses a
+	// sparse checkout of the versionStream/ directory rather than cloning the whole repository
+	SparseCheckout bool
 }
 
 // TeamSettings returns the team settings for the current environment

--- a/pkg/envctx/load.go
+++ b/pkg/envctx/load.go
@@ -91,7 +91,12 @@ func (e *EnvironmentContext) LazyLoad(gclient gitclient.Interface, jxClient vers
 			return fmt.Errorf("failed to add user and token to git url %s: %w", url, err)
 		}
 
-		cloneDir, err := gitclient.CloneToDir(gitter, gitCloneURL, "")
+		var cloneDir string
+		if e.SparseCheckout {
+			cloneDir, err = gitclient.SparseCloneToDir(gitter, gitCloneURL, "", true, "/versionStream/")
+		} else {
+			cloneDir, err = gitclient.CloneToDir(gitter, gitCloneURL, "")
+		}
 		if err != nil {
 			return fmt.Errorf("failed to clone URL %s: %w", gitCloneURL, err)
 		}

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -22,6 +22,11 @@ const (
 	LabelUpdatebot = "updatebot"
 )
 
+// DefaultSparseCheckoutPatterns is the default git sparse-checkout pattern set used when sparse
+// checkout is enabled without explicit patterns. It covers the helmfile and helm promotion rules:
+// the root helmfile, nested helmfiles, the promote config under .jx/ and the helm chart under env/.
+var DefaultSparseCheckoutPatterns = []string{"/helmfile.yaml", "/helmfiles/", "/.jx/", "/env/"}
+
 // Create a pull request against the environment repository for env.
 // The EnvironmentPullRequestOptions are used to provide a Gitter client for performing git operations,
 // a GitProvider client for talking to the git provider,
@@ -68,16 +73,22 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, labels []st
 	}
 
 	var dir string
-	if len(o.SparseCheckoutPatterns) > 0 {
-		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", true, o.SparseCheckoutPatterns...)
+	sparse := o.SparseCheckout || len(o.SparseCheckoutPatterns) > 0
+	if sparse {
+		patterns := o.SparseCheckoutPatterns
+		if len(patterns) == 0 {
+			patterns = DefaultSparseCheckoutPatterns
+		}
+		// forks rebase against the full upstream history, so a shallow clone is unsafe for them
+		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", !o.Fork, patterns...)
 	} else {
 		dir, err = gitclient.CloneToDir(o.Gitter, cloneGitURL, "")
-		if o.BaseBranchName != "" {
-			log.Logger().Infof("checking out remote base branch %s from %s", o.BaseBranchName, gitURL)
-			err = gitclient.CheckoutRemoteBranch(o.Gitter, dir, o.BaseBranchName)
-			if err != nil {
-				return nil, fmt.Errorf("failed to checkout remote branch %s from %s: %w", o.BaseBranchName, gitURL, err)
-			}
+	}
+	if err == nil && o.BaseBranchName != "" {
+		log.Logger().Infof("checking out remote base branch %s from %s", o.BaseBranchName, gitURL)
+		err = gitclient.CheckoutRemoteBranch(o.Gitter, dir, o.BaseBranchName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to checkout remote branch %s from %s: %w", o.BaseBranchName, gitURL, err)
 		}
 	}
 	if err != nil {

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -79,8 +79,12 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, labels []st
 		if len(patterns) == 0 {
 			patterns = DefaultSparseCheckoutPatterns
 		}
-		// forks rebase against the full upstream history, so a shallow clone is unsafe for them
-		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", !o.Fork, patterns...)
+		// a shallow (--depth=1) clone implies --single-branch, so it only fetches the default
+		// branch. That is unsafe when: (a) this is a fork, which rebases against the full upstream
+		// history; or (b) we need to check out a non-default base branch below, whose ref would not
+		// be fetched. In those cases fall back to a full-history clone.
+		shallow := !o.Fork && o.BaseBranchName == ""
+		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", shallow, patterns...)
 		if err != nil {
 			// sparse-checkout is not supported by every git server
 			// fall-back to a full clone if that fails

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -81,6 +81,12 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, labels []st
 		}
 		// forks rebase against the full upstream history, so a shallow clone is unsafe for them
 		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", !o.Fork, patterns...)
+		if err != nil {
+			// sparse-checkout is not supported by every git server
+			// fall-back to a full clone if that fails
+			log.Logger().Warnf("sparse clone of %s failed (%s); falling back to a full clone", cloneGitURLSafe, err)
+			dir, err = gitclient.CloneToDir(o.Gitter, cloneGitURL, "")
+		}
 	} else {
 		dir, err = gitclient.CloneToDir(o.Gitter, cloneGitURL, "")
 	}

--- a/pkg/environments/types.go
+++ b/pkg/environments/types.go
@@ -58,6 +58,7 @@ type EnvironmentPullRequestOptions struct {
 	UseGitHubOAuth         bool
 	Fork                   bool
 	ReusePullRequest       bool
+	SparseCheckout         bool
 	SparseCheckoutPatterns []string
 	Application            string
 }

--- a/pkg/promote/pr.go
+++ b/pkg/promote/pr.go
@@ -95,6 +95,11 @@ func (o *Options) PromoteViaPullRequest(envs []*jxcore.EnvironmentConfig, releas
 
 			// lets check if we need the apps git URL
 			if promoteConfig.Spec.FileRule != nil || promoteConfig.Spec.KptRule != nil {
+				// file/kpt rules write to arbitrary paths, so default sparse clone silently produces an incomplete PR.
+				// Fail fast and tell the user to supply explicit patterns.
+				if o.SparseCheckout && len(o.SparseCheckoutPatterns) == 0 {
+					return fmt.Errorf("promote config in dir %s uses a file/kpt rule which touches arbitrary paths; the default sparse-checkout patterns are insufficient - please pass explicit --sparse-checkout-pattern values (or omit --sparse-checkout)", dir)
+				}
 				if o.AppGitURL == "" {
 					_, gitConf, err := gitclient.FindGitConfigDir("")
 					if err != nil {

--- a/pkg/promote/pr.go
+++ b/pkg/promote/pr.go
@@ -3,18 +3,44 @@ package promote
 import (
 	"fmt"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/jenkins-x-plugins/jx-promote/pkg/environments"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/requirements"
 
 	jxcore "github.com/jenkins-x/jx-api/v4/pkg/apis/core/v4beta1"
 
+	"github.com/jenkins-x-plugins/jx-promote/pkg/apis/promote/v1alpha1"
 	"github.com/jenkins-x-plugins/jx-promote/pkg/promoteconfig"
 	"github.com/jenkins-x-plugins/jx-promote/pkg/rules"
 	"github.com/jenkins-x-plugins/jx-promote/pkg/rules/factory"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient/gitconfig"
+	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 )
+
+// sparsePatternForRule derives the git sparse-checkout pattern (gitignore syntax, root anchored)
+// needed to materialize the target of a file/kpt promote rule so it works under a sparse clone.
+// A FileRule modifies exactly its Path; a KptRule operates within Path/<app>. Returns "" if the
+// target cannot be derived (in which case the caller should fail rather than clone incompletely).
+func sparsePatternForRule(spec v1alpha1.PromoteSpec, appName string) string {
+	if spec.FileRule != nil {
+		p := strings.Trim(spec.FileRule.Path, "/")
+		if p == "" {
+			return ""
+		}
+		return "/" + p
+	}
+	if spec.KptRule != nil {
+		target := strings.Trim(path.Join(spec.KptRule.Path, appName), "/")
+		if target == "" {
+			return ""
+		}
+		return "/" + target + "/"
+	}
+	return ""
+}
 
 func (o *Options) PromoteViaPullRequest(envs []*jxcore.EnvironmentConfig, releaseInfo *ReleaseInfo, draftPR bool) error {
 	version := o.Version
@@ -95,10 +121,21 @@ func (o *Options) PromoteViaPullRequest(envs []*jxcore.EnvironmentConfig, releas
 
 			// lets check if we need the apps git URL
 			if promoteConfig.Spec.FileRule != nil || promoteConfig.Spec.KptRule != nil {
-				// file/kpt rules write to arbitrary paths, so default sparse clone silently produces an incomplete PR.
-				// Fail fast and tell the user to supply explicit patterns.
-				if o.SparseCheckout && len(o.SparseCheckoutPatterns) == 0 {
-					return fmt.Errorf("promote config in dir %s uses a file/kpt rule which touches arbitrary paths; the default sparse-checkout patterns are insufficient - please pass explicit --sparse-checkout-pattern values (or omit --sparse-checkout)", dir)
+				// file/kpt rules write to paths not covered by the default sparse-checkout pattern
+				// set. The promote config itself is available (the default patterns include .jx/), so
+				// we can derive the rule's target path and expand the sparse checkout to include it
+				// rather than failing.
+				if o.SparseCheckout || len(o.SparseCheckoutPatterns) > 0 {
+					pattern := sparsePatternForRule(promoteConfig.Spec, o.Application)
+					if pattern == "" {
+						return fmt.Errorf("promote config in dir %s uses a file/kpt rule whose target path cannot be derived; please pass explicit --sparse-checkout-pattern values (or omit --sparse-checkout)", dir)
+					}
+					// git sparse-checkout add appends the pattern and re-applies it to the working
+					// tree, lazily fetching the now-included blobs from the (blobless) clone
+					if _, err := o.Gitter.Command(dir, "sparse-checkout", "add", pattern); err != nil {
+						return fmt.Errorf("failed to expand sparse checkout with file/kpt rule path %q in dir %s: %w", pattern, dir, err)
+					}
+					log.Logger().Infof("expanded sparse checkout to include file/kpt rule path %s", pattern)
 				}
 				if o.AppGitURL == "" {
 					_, gitConf, err := gitclient.FindGitConfigDir("")

--- a/pkg/promote/pr_internal_test.go
+++ b/pkg/promote/pr_internal_test.go
@@ -1,0 +1,75 @@
+//go:build unit
+// +build unit
+
+package promote
+
+import (
+	"testing"
+
+	"github.com/jenkins-x-plugins/jx-promote/pkg/apis/promote/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSparsePatternForRule(t *testing.T) {
+	testCases := []struct {
+		name     string
+		spec     v1alpha1.PromoteSpec
+		appName  string
+		expected string
+	}{
+		{
+			name:     "file rule modifies a single file",
+			spec:     v1alpha1.PromoteSpec{FileRule: &v1alpha1.FileRule{Path: "Makefile"}},
+			appName:  "myapp",
+			expected: "/Makefile",
+		},
+		{
+			name:     "file rule with a nested path",
+			spec:     v1alpha1.PromoteSpec{FileRule: &v1alpha1.FileRule{Path: "config/values.yaml"}},
+			appName:  "myapp",
+			expected: "/config/values.yaml",
+		},
+		{
+			name:     "file rule with a leading slash is normalised",
+			spec:     v1alpha1.PromoteSpec{FileRule: &v1alpha1.FileRule{Path: "/Makefile"}},
+			appName:  "myapp",
+			expected: "/Makefile",
+		},
+		{
+			name:     "file rule without a path cannot be derived",
+			spec:     v1alpha1.PromoteSpec{FileRule: &v1alpha1.FileRule{}},
+			appName:  "myapp",
+			expected: "",
+		},
+		{
+			name:     "kpt rule covers the namespace/app subtree",
+			spec:     v1alpha1.PromoteSpec{KptRule: &v1alpha1.KptRule{Path: "namespaces/jx-staging"}},
+			appName:  "myapp",
+			expected: "/namespaces/jx-staging/myapp/",
+		},
+		{
+			name:     "kpt rule with an empty path falls back to the app dir at root",
+			spec:     v1alpha1.PromoteSpec{KptRule: &v1alpha1.KptRule{}},
+			appName:  "myapp",
+			expected: "/myapp/",
+		},
+		{
+			name:     "kpt rule with neither path nor app cannot be derived",
+			spec:     v1alpha1.PromoteSpec{KptRule: &v1alpha1.KptRule{}},
+			appName:  "",
+			expected: "",
+		},
+		{
+			name:     "helm/helmfile rules need no extra pattern",
+			spec:     v1alpha1.PromoteSpec{HelmfileRule: &v1alpha1.HelmfileRule{Path: "helmfile.yaml"}},
+			appName:  "myapp",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sparsePatternForRule(tc.spec, tc.appName), tc.name)
+		})
+	}
+}

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -386,10 +386,8 @@ func (o *Options) Run() error {
 		o.GitClient = cli.NewCLIClient("", o.CommandRunner)
 	}
 
+	// file/kpt promote rules touch arbitrary paths so default sparse patterns are insufficient
 	o.DevEnvContext.SparseCheckout = o.SparseCheckout || len(o.SparseCheckoutPatterns) > 0
-	if o.DevEnvContext.SparseCheckout && len(o.SparseCheckoutPatterns) == 0 && o.AppGitURL != "" {
-		log.Logger().Warnf("sparse checkout is enabled with default patterns; file/kpt promote rules may need explicit --sparse-checkout-pattern values")
-	}
 
 	err = o.DevEnvContext.LazyLoad(o.GitClient, o.JXClient, o.Namespace, o.Git(), o.Dir)
 	if err != nil {

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -197,6 +197,8 @@ func (o *Options) AddOptions(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.PullRequestPollTime, optionPullRequestPollTime, "", "20s", "Poll time when waiting for a Pull Request to merge")
 	cmd.Flags().StringVarP(&o.DevEnvContext.GitUsername, "git-user", "", "", "Git username used to clone the development environment. If not specified its loaded from the git credentials file")
 	cmd.Flags().StringVarP(&o.DevEnvContext.GitToken, "git-token", "", "", "Git token used to clone the development environment. If not specified its loaded from the git credentials file")
+	cmd.Flags().BoolVarP(&o.SparseCheckout, "sparse-checkout", "", false, "Enables sparse git checkout of the environment and dev (version stream) repositories to reduce the clone footprint. Uses a default pattern set (helmfile.yaml, helmfiles/, .jx/, env/) when no --sparse-checkout-pattern is given. NOTE: file/kpt promote rules touch arbitrary paths and need explicit --sparse-checkout-pattern values")
+	cmd.Flags().StringArrayVarP(&o.SparseCheckoutPatterns, "sparse-checkout-pattern", "", nil, "Explicit git sparse-checkout patterns (gitignore syntax). Implies --sparse-checkout and overrides the default pattern set")
 
 	cmd.Flags().BoolVarP(&o.NoHelmUpdate, "no-helm-update", "", false, "Allows the 'helm repo update' command if you are sure your local helm cache is up to date with the version you wish to promote")
 	cmd.Flags().BoolVarP(&o.NoMergePullRequest, "no-merge", "", false, "Disables automatic merge of promote Pull Requests")
@@ -382,6 +384,11 @@ func (o *Options) Run() error {
 	jxClient := o.JXClient
 	if o.GitClient == nil {
 		o.GitClient = cli.NewCLIClient("", o.CommandRunner)
+	}
+
+	o.DevEnvContext.SparseCheckout = o.SparseCheckout || len(o.SparseCheckoutPatterns) > 0
+	if o.DevEnvContext.SparseCheckout && len(o.SparseCheckoutPatterns) == 0 && o.AppGitURL != "" {
+		log.Logger().Warnf("sparse checkout is enabled with default patterns; file/kpt promote rules may need explicit --sparse-checkout-pattern values")
 	}
 
 	err = o.DevEnvContext.LazyLoad(o.GitClient, o.JXClient, o.Namespace, o.Git(), o.Dir)

--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -1128,9 +1128,26 @@ func TestPromoteIntegrationHelmfileSparseCheckout(t *testing.T) {
 	assert.Contains(t, sparseClone, "myapp", "promoted helmfile should reference the promoted app")
 }
 
+// TestPromoteIntegrationHelmfileSparseCheckoutExplicitPatterns asserts that supplying explicit
+// --sparse-checkout-pattern values (a) implies a sparse checkout even without --sparse-checkout and
+// (b) overrides the default pattern set while still producing the same promoted helmfile as a full
+// clone. The patterns here are the minimal set a helmfile promotion needs.
+func TestPromoteIntegrationHelmfileSparseCheckoutExplicitPatterns(t *testing.T) {
+	gitURL := "https://github.com/jx3-gitops-repositories/jx3-gke-vault"
+
+	fullClone := runHelmfileSparsePromotion(t, gitURL, false)
+	// note: SparseCheckout is left false - the explicit patterns alone must enable the sparse clone
+	explicitClone := runHelmfileSparsePromotion(t, gitURL, false, "/helmfile.yaml", "/helmfiles/")
+
+	assert.Equal(t, fullClone, explicitClone, "promoted helmfile should be identical for a full clone vs an explicit-pattern sparse clone")
+	assert.Contains(t, explicitClone, "myapp", "promoted helmfile should reference the promoted app")
+}
+
 // runHelmfileSparsePromotion runs a helmfile promotion against gitURL, optionally enabling sparse
-// checkout, and returns the content of the promoted nested helmfile so callers can compare it
-func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool) string {
+// checkout (and optionally with explicit sparse-checkout patterns), and returns the content of the
+// promoted nested helmfile so callers can compare it. A sparse checkout is performed when sparse is
+// true or when explicit patterns are supplied.
+func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool, patterns ...string) string {
 	version := "1.2.3"
 	appName := "myapp"
 	envName := "staging"
@@ -1149,6 +1166,7 @@ func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool) string
 	po.CommandRunner = runner.Run
 	po.AppGitURL = "https://github.com/myorg/myapp.git"
 	po.SparseCheckout = sparse
+	po.SparseCheckoutPatterns = patterns
 
 	devEnv := jxtesthelpers.CreateTestDevEnvironment(ns)
 
@@ -1190,11 +1208,15 @@ func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool) string
 
 	require.NotEmpty(t, po.OutDir, "should have populated an out dir (sparse=%v)", sparse)
 
+	// a sparse checkout happens when explicitly enabled or when explicit patterns are supplied
+	isSparse := sparse || len(patterns) > 0
+
 	// verify the sparse clone really did reduce the footprint: versionStream/ is present in a full
-	// clone but excluded by the default sparse-checkout patterns, while the promoted dirs remain
+	// clone but excluded by both the default and the explicit sparse-checkout patterns, while the
+	// promoted dirs remain
 	versionStreamExists, err := files.DirExists(filepath.Join(po.OutDir, "versionStream"))
-	require.NoError(t, err, "failed to check versionStream dir (sparse=%v)", sparse)
-	if sparse {
+	require.NoError(t, err, "failed to check versionStream dir (sparse=%v)", isSparse)
+	if isSparse {
 		assert.False(t, versionStreamExists, "sparse clone should not check out versionStream/")
 	} else {
 		assert.True(t, versionStreamExists, "full clone should check out versionStream/")

--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -1121,11 +1121,16 @@ func NewFakeRunnerWithSparseGitClone() *fakerunner.FakeRunner {
 func TestPromoteIntegrationHelmfileSparseCheckout(t *testing.T) {
 	gitURL := "https://github.com/jx3-gitops-repositories/jx3-gke-vault"
 
-	fullClone := runHelmfileSparsePromotion(t, gitURL, false)
-	sparseClone := runHelmfileSparsePromotion(t, gitURL, true)
+	fullClone, _ := runHelmfileSparsePromotion(t, gitURL, "", false)
+	sparseClone, sparseRunner := runHelmfileSparsePromotion(t, gitURL, "", true)
 
 	assert.Equal(t, fullClone, sparseClone, "promoted helmfile should be identical for a full clone vs a sparse clone")
 	assert.Contains(t, sparseClone, "myapp", "promoted helmfile should reference the promoted app")
+
+	// with no base branch the sparse clone should be shallow to minimise the fetch
+	cloneArgs := findGitCommandArgs(sparseRunner, "clone")
+	require.NotNil(t, cloneArgs, "expected a git clone command to have been issued")
+	assert.Contains(t, cloneArgs, "--depth=1", "sparse clone should be shallow when no base branch is requested")
 }
 
 // TestPromoteIntegrationHelmfileSparseCheckoutExplicitPatterns asserts that supplying explicit
@@ -1135,19 +1140,49 @@ func TestPromoteIntegrationHelmfileSparseCheckout(t *testing.T) {
 func TestPromoteIntegrationHelmfileSparseCheckoutExplicitPatterns(t *testing.T) {
 	gitURL := "https://github.com/jx3-gitops-repositories/jx3-gke-vault"
 
-	fullClone := runHelmfileSparsePromotion(t, gitURL, false)
+	fullClone, _ := runHelmfileSparsePromotion(t, gitURL, "", false)
 	// note: SparseCheckout is left false - the explicit patterns alone must enable the sparse clone
-	explicitClone := runHelmfileSparsePromotion(t, gitURL, false, "/helmfile.yaml", "/helmfiles/")
+	explicitClone, _ := runHelmfileSparsePromotion(t, gitURL, "", false, "/helmfile.yaml", "/helmfiles/")
 
 	assert.Equal(t, fullClone, explicitClone, "promoted helmfile should be identical for a full clone vs an explicit-pattern sparse clone")
 	assert.Contains(t, explicitClone, "myapp", "promoted helmfile should reference the promoted app")
 }
 
+// TestPromoteIntegrationHelmfileSparseCheckoutBaseBranch asserts that when a non-default base branch
+// is requested the sparse clone is NOT shallow. A shallow (--depth=1) clone implies --single-branch,
+// so it only fetches the default branch and the subsequent base-branch checkout would fail to find
+// the ref. The promoted helmfile must still match a full clone.
+func TestPromoteIntegrationHelmfileSparseCheckoutBaseBranch(t *testing.T) {
+	gitURL := "https://github.com/jx3-gitops-repositories/jx3-gke-vault"
+
+	fullClone, _ := runHelmfileSparsePromotion(t, gitURL, "", false)
+	baseBranchClone, runner := runHelmfileSparsePromotion(t, gitURL, "my-base-branch", true)
+
+	assert.Equal(t, fullClone, baseBranchClone, "promoted helmfile should be identical for a full clone vs a base-branch sparse clone")
+
+	cloneArgs := findGitCommandArgs(runner, "clone")
+	require.NotNil(t, cloneArgs, "expected a git clone command to have been issued")
+	assert.NotContains(t, cloneArgs, "--depth=1", "sparse clone must not be shallow when a base branch is requested, as --depth=1 implies --single-branch and would omit the base branch ref")
+}
+
+// findGitCommandArgs returns the args of the first recorded git command whose subcommand matches, or
+// nil if none was issued.
+func findGitCommandArgs(runner *fakerunner.FakeRunner, subcommand string) []string {
+	for _, c := range runner.OrderedCommands {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == subcommand {
+			return c.Args
+		}
+	}
+	return nil
+}
+
 // runHelmfileSparsePromotion runs a helmfile promotion against gitURL, optionally enabling sparse
 // checkout (and optionally with explicit sparse-checkout patterns), and returns the content of the
-// promoted nested helmfile so callers can compare it. A sparse checkout is performed when sparse is
-// true or when explicit patterns are supplied.
-func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool, patterns ...string) string {
+// promoted nested helmfile so callers can compare it along with the fake runner so callers can
+// assert on the git commands that were issued. A sparse checkout is performed when sparse is true or
+// when explicit patterns are supplied. When baseBranch is non-empty the promotion targets that base
+// branch rather than the default branch.
+func runHelmfileSparsePromotion(t *testing.T, gitURL, baseBranch string, sparse bool, patterns ...string) (string, *fakerunner.FakeRunner) {
 	version := "1.2.3"
 	appName := "myapp"
 	envName := "staging"
@@ -1167,6 +1202,7 @@ func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool, patter
 	po.AppGitURL = "https://github.com/myorg/myapp.git"
 	po.SparseCheckout = sparse
 	po.SparseCheckoutPatterns = patterns
+	po.BaseBranchName = baseBranch
 
 	devEnv := jxtesthelpers.CreateTestDevEnvironment(ns)
 
@@ -1226,5 +1262,5 @@ func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool, patter
 	require.FileExists(t, helmfile, "should have created the promoted helmfile (sparse=%v)", sparse)
 	data, err := os.ReadFile(helmfile)
 	require.NoError(t, err, "failed to read promoted helmfile %s (sparse=%v)", helmfile, sparse)
-	return string(data)
+	return string(data), runner
 }

--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -23,6 +23,7 @@ import (
 	v1fake "github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned/fake"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner/fakerunner"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/stringhelpers"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -1088,4 +1089,120 @@ func NewFakeRunnerWithGitClone() *fakerunner.FakeRunner {
 		return "", nil
 	}
 	return runner
+}
+
+// NewFakeRunnerWithSparseGitClone is like NewFakeRunnerWithGitClone but also performs the
+// sparse-checkout and checkout commands for real so that sparse clones populate the working tree
+func NewFakeRunnerWithSparseGitClone() *fakerunner.FakeRunner {
+	runner := &fakerunner.FakeRunner{}
+
+	validGitCommands := []string{"clone", "rev-parse", "status", "sparse-checkout"}
+
+	runner.CommandRunner = func(c *cmdrunner.Command) (string, error) {
+		if c.Name == "git" && len(c.Args) > 0 {
+			cmd := c.Args[0]
+			// the bare `git checkout` issued by the sparse clone must run for real to populate the
+			// working tree, but the later PR-branch checkout (which has a branch arg) stays faked
+			realCheckout := cmd == "checkout" && len(c.Args) == 1
+			if stringhelpers.StringArrayIndex(validGitCommands, cmd) >= 0 || realCheckout {
+				// lets really perform the git command
+				return cmdrunner.DefaultCommandRunner(c)
+			}
+		}
+
+		// lets fake out other commands
+		return "", nil
+	}
+	return runner
+}
+
+// TestPromoteIntegrationHelmfileSparseCheckout asserts that promoting via a sparse clone (using the
+// default sparse-checkout patterns) produces exactly the same promoted helmfile as a full clone
+func TestPromoteIntegrationHelmfileSparseCheckout(t *testing.T) {
+	gitURL := "https://github.com/jx3-gitops-repositories/jx3-gke-vault"
+
+	fullClone := runHelmfileSparsePromotion(t, gitURL, false)
+	sparseClone := runHelmfileSparsePromotion(t, gitURL, true)
+
+	assert.Equal(t, fullClone, sparseClone, "promoted helmfile should be identical for a full clone vs a sparse clone")
+	assert.Contains(t, sparseClone, "myapp", "promoted helmfile should reference the promoted app")
+}
+
+// runHelmfileSparsePromotion runs a helmfile promotion against gitURL, optionally enabling sparse
+// checkout, and returns the content of the promoted nested helmfile so callers can compare it
+func runHelmfileSparsePromotion(t *testing.T, gitURL string, sparse bool) string {
+	version := "1.2.3"
+	appName := "myapp"
+	envName := "staging"
+	ns := "jx"
+
+	runner := NewFakeRunnerWithSparseGitClone()
+
+	_, po := promote.NewCmdPromote()
+	po.DisableGitConfig = true
+	po.Application = appName
+	po.Version = version
+	po.Environments = []string{envName}
+	po.NoPoll = true
+	po.BatchMode = true
+	po.GitKind = "fake"
+	po.CommandRunner = runner.Run
+	po.AppGitURL = "https://github.com/myorg/myapp.git"
+	po.SparseCheckout = sparse
+
+	devEnv := jxtesthelpers.CreateTestDevEnvironment(ns)
+
+	kubeObjects := []runtime.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+				Labels: map[string]string{
+					"tag":  "",
+					"team": "jx",
+					"env":  "dev",
+				},
+			},
+		},
+	}
+	jxObjects := []runtime.Object{
+		devEnv,
+	}
+	po.DevEnvContext.Requirements = &jxcore.RequirementsConfig{
+		Environments: []jxcore.EnvironmentConfig{
+			{
+				Key:               envName,
+				Namespace:         "jx-" + envName,
+				PromotionStrategy: v1.PromotionStrategyTypeAutomatic,
+				GitURL:            gitURL,
+			},
+		},
+	}
+	po.DevEnvContext.VersionResolver = jxtesthelpers.CreateTestVersionResolver(t)
+
+	po.KubeClient = fake.NewSimpleClientset(kubeObjects...)
+	po.JXClient = v1fake.NewSimpleClientset(jxObjects...)
+	po.Namespace = ns
+	po.Build = "1"
+	po.Pipeline = "myorg/myapp/master"
+
+	err := po.Run()
+	require.NoError(t, err, "failed to run promotion (sparse=%v)", sparse)
+
+	require.NotEmpty(t, po.OutDir, "should have populated an out dir (sparse=%v)", sparse)
+
+	// verify the sparse clone really did reduce the footprint: versionStream/ is present in a full
+	// clone but excluded by the default sparse-checkout patterns, while the promoted dirs remain
+	versionStreamExists, err := files.DirExists(filepath.Join(po.OutDir, "versionStream"))
+	require.NoError(t, err, "failed to check versionStream dir (sparse=%v)", sparse)
+	if sparse {
+		assert.False(t, versionStreamExists, "sparse clone should not check out versionStream/")
+	} else {
+		assert.True(t, versionStreamExists, "full clone should check out versionStream/")
+	}
+
+	helmfile := filepath.Join(po.OutDir, "helmfiles", "jx-"+envName, "helmfile.yaml")
+	require.FileExists(t, helmfile, "should have created the promoted helmfile (sparse=%v)", sparse)
+	data, err := os.ReadFile(helmfile)
+	require.NoError(t, err, "failed to read promoted helmfile %s (sparse=%v)", helmfile, sparse)
+	return string(data)
 }


### PR DESCRIPTION
### Changes
* Add `--sparse-checkout` and `--sparse-checkout-pattern` flags to `promote`, applying to both cluster and application repositories:
  * Add a default sparse-checkout pattern set (`helmfile.yaml`, `helmfiles/`, `.jx/`, `env/`) used when no explicit patterns are given
  * Derive and add the sparse-checkout pattern for file/kpt promote rules at runtime, since those rules write to arbitrary paths not covered by the defaults
  * Fall back to a full clone when the git server does not support sparse checkout
  * Disable shallow cloning for forks, which must rebase against full upstream history
* Add unit tests  and integration tests
                                                                                                                                                                                                                    
### Context         

Fully cloning the entire cluster and application repositories is slow and wasteful when:
* a promotion only touches a handful of files
* the full git history is not needed

A sparse checkout fetches only the paths a promotion needs (default: `helmfile.yaml`, `helmfiles/`, `.jx/`, `env/`), while a shallow clone ignores the git history from the fetched branch. Enabling these enables faster release steps, particularly for larger repos with large commit histories.

There are exceptions to this that need to be handled with care, namely:
* file/kpt rules that write to arbitrary paths - checkout these paths in addition to specified sparse paths
* base branch is _not_ the default - ignore shallow clone
* forks require a full history - do a full clone
* some git servers don't support sparse checkouts - do a full clone